### PR TITLE
Project Structure Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # uwo_athlete_surveyor
+
 Provides means for intercollegiate faculty to better keep in touch with the strain on students, with a future plans to allow for analytics
+
+# Contents
+- [Code Standards](#code-standards)
+- [Project Structure](#project-structure)
+- [Navigation](#navigation)
+
+# Code Standards 
+## Responsibilities
+When in doubt... use SOLID principles / rely on the following<br>
+Credit to [VerygoodVentures](https://verygood.ventures/blog/very-good-flutter-architecture) 
+- **Data layer**: This layer interacts directly with an API (REST API or a device API).
+- **Domain layer**: This layer transforms or manipulates the data that the API provides.
+- **Presentation layer**: This layer presents the app content and triggers events that modify the application state
+
+# Project Structure
+`assets` - contains non-code entities, like images or videos<br>
+`widgets` - holds widget structure info, does NOT store theme!<br>
+`views` - holds "pages" which use widgets to **present** to the user<br>
+`test` - stores tests that enforce business logic constraints<br>
+`services` - non-renderable func. such as interacting with an API
+
+## Navigation
+> NOTE: This is the first leg of the developmental milestone we're embarking on.  Changes will be frequent, and may be jarring at times.
+
+Initially, we'll be drafting mockup screens with dummy data, and in order to keep up with individual developers' academic obligations, we'll opt for either a `TabBarView` or (less likely) a `Navigator` to jump between these early-stage prototypes.
+
+In *future phases*, a `Navigator` or something more robust may be worthwhile since data flow between pages will play a key role in the desired functionality.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # uwo_athlete_surveyor
+
 Provides means for intercollegiate faculty to better keep in touch with the strain on students, with a future plans to allow for analytics
+
+# Contents
+- [Code Standards](#code-standards)
+- [Project Structure](#project-structure)
+- [Navigation](#navigation)
+<!-- - [Commits](Commits) -->
+
+# Code Standards 
+## Responsibilities
+When in doubt... use SOLID principles / rely on the following<br>
+Credit to [VerygoodVentures](https://verygood.ventures/blog/very-good-flutter-architecture) 
+- **Data layer**: This layer interacts directly with an API (REST API or a device API).
+- **Domain layer**: This layer transforms or manipulates the data that the API provides.
+- **Presentation layer**: This layer presents the app content and triggers events that modify the application state
+
+# Project Structure
+`assets` - contains non-code entities, like images or videos<br>
+`widgets` - holds widget structure info, does NOT store theme!<br>
+`views` - holds "pages" which use widgets to **present** to the user<br>
+`test` - stores tests that enforce business logic constraints<br>
+`services` - non-renderable func. such as interacting with an API
+
+## Navigation
+> NOTE: This is the first leg of the developmental milestone we're embarking on.  Changes will be frequent, and may be jarring at times.
+
+Initially, we'll be drafting mockup screens with dummy data, and in order to keep up with individual developers' academic obligations, we'll opt for either a `TabBarView` or (less likely) a `Navigator` to jump between these early-stage prototypes.
+
+In *future phases*, a `Navigator` or something more robust may be worthwhile since data flow between pages will play a key role in the desired functionality.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,11 @@
+/**
+ * Date Started:     3/30/24
+ * Desc: 
+ * Entry point for student-faculty survey orchestrating app.
+ * 
+ * Authors: Josh, Vince, Amanda, Matt.
+ * Version:          0.0.1
+ */
 import 'package:flutter/material.dart';
 
 void main() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,10 @@
-/**
- * Date Started:     3/30/24
- * Desc: 
- * Entry point for student-faculty survey orchestrating app.
- * 
- * Authors: Josh, Vince, Amanda, Matt.
- * Version:          0.0.1
- */
+// ignore: dangling_library_doc_comments
+/// Date Started:     3/30/24
+/// Desc: 
+/// Entry point for student-faculty survey orchestrating app.
+/// 
+/// Authors: Josh, Vince, Amanda, Matt.
+/// Version:          0.0.1
 import 'package:flutter/material.dart';
 
 void main() {


### PR DESCRIPTION
add: subdirectories for `lib` to mitigate code clutter (`views`, `models`, `services`, `widgets`, `test` and `assets`)

edit: updated README.md